### PR TITLE
cb lategame nerfs

### DIFF
--- a/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Base.SC2Data/GameData/UpgradeData.xml
@@ -5140,45 +5140,45 @@
         <LeaderAlias value="UmojanBasicUnitUpgrade5"/>
     </CUpgrade>
     <CUpgrade id="UmojanBasicUnitUpgrade5222422423222222224">
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Melee]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[NoProc]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Ranged]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Spell]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Splash]" Value="0.2"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Melee]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[NoProc]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Ranged]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Spell]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Splash]" Value="0.1"/>
         <EditorCategories value="Race:Terran,UpgradeType:Talents"/>
         <LeaderAlias value="UmojanBasicUnitUpgrade5"/>
     </CUpgrade>
     <CUpgrade id="UmojanBasicUnitUpgrade52224224232222222242">
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Melee]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[NoProc]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Ranged]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Spell]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Splash]" Value="0.2"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Melee]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[NoProc]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Ranged]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Spell]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Splash]" Value="0.1"/>
         <EditorCategories value="Race:Terran,UpgradeType:Talents"/>
         <LeaderAlias value="UmojanBasicUnitUpgrade5"/>
     </CUpgrade>
     <CUpgrade id="UmojanBasicUnitUpgrade522242242322222222422">
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Melee]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[NoProc]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Ranged]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Spell]" Value="0.2"/>
-        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Splash]" Value="0.2"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Melee]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[NoProc]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Ranged]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Spell]" Value="0.1"/>
+        <EffectArray Reference="Behavior,AntamoAirAll,Modification.DamageDealtFraction[Splash]" Value="0.1"/>
         <EditorCategories value="Race:Terran,UpgradeType:Talents"/>
         <LeaderAlias value="UmojanBasicUnitUpgrade5"/>
     </CUpgrade>
     <CUpgrade id="UmojanBasicUnitUpgrade5222422423222222224222">
-        <EffectArray Reference="Behavior,AntamoAirAll103,Modification.DamageDealtAttributeMultiplier[Light]" Value="0.5"/>
+        <EffectArray Reference="Behavior,AntamoAirAll103,Modification.DamageDealtAttributeMultiplier[Light]" Value="0.3"/>
         <EditorCategories value="Race:Terran,UpgradeType:Talents"/>
         <LeaderAlias value="UmojanBasicUnitUpgrade5"/>
     </CUpgrade>
     <CUpgrade id="UmojanBasicUnitUpgrade52224224232222222242222">
-        <EffectArray Reference="Behavior,AntamoAirAll103,Modification.DamageDealtAttributeMultiplier[Armored]" Value="0.5"/>
+        <EffectArray Reference="Behavior,AntamoAirAll103,Modification.DamageDealtAttributeMultiplier[Armored]" Value="0.3"/>
         <EditorCategories value="Race:Terran,UpgradeType:Talents"/>
         <LeaderAlias value="UmojanBasicUnitUpgrade5"/>
     </CUpgrade>
     <CUpgrade id="UmojanBasicUnitUpgrade522242242322222222422222">
-        <EffectArray Reference="Behavior,AntamoAirAll103,Modification.DamageDealtAttributeMultiplier[Massive]" Value="0.5"/>
-        <EffectArray Reference="Behavior,AntamoAirAll103,Modification.DamageDealtAttributeMultiplier[Heroic]" Value="0.5"/>
+        <EffectArray Reference="Behavior,AntamoAirAll103,Modification.DamageDealtAttributeMultiplier[Massive]" Value="0.3"/>
+        <EffectArray Reference="Behavior,AntamoAirAll103,Modification.DamageDealtAttributeMultiplier[Heroic]" Value="0.3"/>
         <EditorCategories value="Race:Terran,UpgradeType:Talents"/>
         <LeaderAlias value="UmojanBasicUnitUpgrade5"/>
     </CUpgrade>
@@ -10014,7 +10014,7 @@
         <EffectArray Operation="Set" Reference="Effect,DevourerMPWeaponSearch2,AreaArray[0].Radius" Value="2"/>
     </CUpgrade>
     <CUpgrade id="UnknownUpgrade572">
-        <EffectArray Operation="Set" Reference="Weapon,GuardianMPWeapon3,Range" Value="13"/>
+        <EffectArray Operation="Set" Reference="Weapon,GuardianMPWeapon3,Range" Value="12"/>
     </CUpgrade>
     <CUpgrade id="UnknownUpgrade58">
         <EffectArray Reference="Effect,VolatileBurstUCorrosive3,Amount" Value="10"/>

--- a/Base.SC2Data/GameData/WeaponData.xml
+++ b/Base.SC2Data/GameData/WeaponData.xml
@@ -3050,7 +3050,7 @@
         <DisplayEffect value="VortexKillDamageDummy222"/>
         <TargetFilters value="Light,Visible;Air,Massive,Heroic,Missile,Dead,Hidden"/>
         <MinScanRange value="9"/>
-        <Range value="9"/>
+        <Range value="8"/>
         <Marker Link="Weapon/GuassRifle8"/>
         <Cost>
             <Cooldown Link="Weapon/GuassRifle8"/>


### PR DESCRIPTION
- increased devourer cost by 50/0, guardian cost by 25/25
- reduced upgraded guardian range by 1
- reduced angelbusher range by 1
- halved effect of former damage upgrades
- reduced effect of dominant damage upgrades to 30%